### PR TITLE
feat: add distinction between download and install size

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "ea862ec2b3d5654762bd8a7bda51e8d0102a7402f4e7b54ac1de3d12400242e7",
+  "originHash" : "d8f809711f825dbd6cbd6e40966828ccec42fdc4937a9f7ee4c87bfe830a5d40",
   "pins" : [
     {
       "identity" : "command",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/FileSystem.git",
       "state" : {
-        "revision" : "a74971566c517dd4e7ff6895b11d4d44aee2c7e9",
-        "version" : "0.7.13"
+        "revision" : "f4cf9cbd670162f9efc3a7028ff70521467851b7",
+        "version" : "0.7.14"
       }
     },
     {
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio",
       "state" : {
-        "revision" : "c51907a839e63ebf0ba2076bba73dd96436bd1b9",
-        "version" : "2.81.0"
+        "revision" : "6e17bc946821e550b88d22fd964423f70f1ce42d",
+        "version" : "2.82.0"
       }
     },
     {

--- a/Sources/Rosalind/Rosalind.swift
+++ b/Sources/Rosalind/Rosalind.swift
@@ -97,10 +97,19 @@ public struct Rosalind: Rosalindable {
             )
             let appBundle = try await appBundleLoader.load(appBundlePath)
 
+            let downloadSize: Int?
+            switch path.extension {
+            case "ipa":
+                downloadSize = try fileSize(at: path)
+            default:
+                downloadSize = nil
+            }
+
             return AppBundleReport(
                 bundleId: appBundle.infoPlist.bundleId,
                 name: appBundle.infoPlist.name,
-                size: artifact.size,
+                installSize: artifact.size,
+                downloadSize: downloadSize,
                 platforms: appBundle.infoPlist.supportedPlatforms,
                 version: appBundle.infoPlist.version,
                 artifacts: artifact.children ?? []
@@ -204,7 +213,11 @@ public struct Rosalind: Rosalindable {
         if artifact.isDirectory {
             return children.map(\.size).reduce(0, +)
         } else {
-            return ((try FileManager.default.attributesOfItem(atPath: artifact.path.pathString))[.size] as? Int) ?? 0
+            return try fileSize(at: artifact.path)
         }
+    }
+
+    private func fileSize(at path: AbsolutePath) throws -> Int {
+        ((try FileManager.default.attributesOfItem(atPath: path.pathString))[.size] as? Int) ?? 0
     }
 }

--- a/Sources/Rosalind/RosalindReport.swift
+++ b/Sources/Rosalind/RosalindReport.swift
@@ -4,8 +4,12 @@ public struct AppBundleReport: Sendable, Codable, Equatable {
     public let bundleId: String
     /// The app name
     public let name: String
-    /// The app size in bytes
-    public let size: Int
+    /// The app install size in bytes. This is the size of the `.app` bundle and represents the value that will be installed on
+    /// the device.
+    public let installSize: Int
+    /// The app download size in bytes. Only available for `.ipa`. It represents the compressed size that the users will end up
+    /// downloading over the network.
+    public let downloadSize: Int?
     /// List of supported platforms, such as `iPhoneSimulator`. List of possible values is the same as for
     /// `CFBundleSupportedPlatforms`.
     public let platforms: [String]
@@ -17,14 +21,16 @@ public struct AppBundleReport: Sendable, Codable, Equatable {
     public init(
         bundleId: String,
         name: String,
-        size: Int,
+        installSize: Int,
+        downloadSize: Int?,
         platforms: [String],
         version: String,
         artifacts: [AppBundleArtifact]
     ) {
         self.bundleId = bundleId
         self.name = name
-        self.size = size
+        self.installSize = installSize
+        self.downloadSize = downloadSize
         self.platforms = platforms
         self.version = version
         self.artifacts = artifacts

--- a/Tests/RosalindTests/RosalindTests.swift
+++ b/Tests/RosalindTests/RosalindTests.swift
@@ -66,7 +66,8 @@ struct RosalindTests {
                 got == AppBundleReport(
                     bundleId: "com.App",
                     name: "App",
-                    size: 21,
+                    installSize: 21,
+                    downloadSize: nil,
                     platforms: ["iPhoneOS"],
                     version: "1.0",
                     artifacts: [

--- a/Tests/RosalindTests/__Snapshots__/RosalindAcceptanceTests/ios_app.1
+++ b/Tests/RosalindTests/__Snapshots__/RosalindAcceptanceTests/ios_app.1
@@ -32,10 +32,10 @@
     }
   ],
   "bundleId" : "dev.tuist.rosalind.App",
+  "installSize" : 214801,
   "name" : "App",
   "platforms" : [
     "iPhoneOS"
   ],
-  "size" : 214801,
   "version" : "1.0"
 }

--- a/Tests/RosalindTests/__Snapshots__/RosalindAcceptanceTests/ios_app_ipa.1
+++ b/Tests/RosalindTests/__Snapshots__/RosalindAcceptanceTests/ios_app_ipa.1
@@ -40,10 +40,11 @@
     }
   ],
   "bundleId" : "dev.tuist.rosalind.App",
+  "downloadSize" : 23086,
+  "installSize" : 115517,
   "name" : "App",
   "platforms" : [
     "iPhoneOS"
   ],
-  "size" : 115517,
   "version" : "1.0"
 }

--- a/Tests/RosalindTests/__Snapshots__/RosalindAcceptanceTests/ios_app_xcarchive.1
+++ b/Tests/RosalindTests/__Snapshots__/RosalindAcceptanceTests/ios_app_xcarchive.1
@@ -40,10 +40,10 @@
     }
   ],
   "bundleId" : "dev.tuist.rosalind.App",
+  "installSize" : 115517,
   "name" : "App",
   "platforms" : [
     "iPhoneOS"
   ],
-  "size" : 115517,
   "version" : "1.0"
 }


### PR DESCRIPTION
For `.ipa`, we can distinguish between "download" and "install" size. Install size is the actual size of the unarchived `.ipa` – in other words, what gets installed on the device. On the other hand, the download size is simply the size of the compressed contents, which is the size of the `.ipa`.