### PR TITLE
fix: wrong asset path

### DIFF
--- a/Sources/Rosalind/Rosalind.swift
+++ b/Sources/Rosalind/Rosalind.swift
@@ -169,8 +169,8 @@ public struct Rosalind: Rosalindable {
 
                 return AppBundleArtifact(
                     artifactType: .asset,
-                    path: try RelativePath(validating: renditionName)
-                        .appending(artifact.path.relative(to: baseArtifact.path)).pathString,
+                    path: try RelativePath(validating: baseArtifact.path.basename)
+                        .appending(artifact.path.appending(component: renditionName).relative(to: baseArtifact.path)).pathString,
                     size: sizeOnDisk,
                     shasum: sha1Digest.lowercased(),
                     children: nil

--- a/Tests/RosalindTests/__Snapshots__/RosalindAcceptanceTests/ios_app.1
+++ b/Tests/RosalindTests/__Snapshots__/RosalindAcceptanceTests/ios_app.1
@@ -17,19 +17,19 @@
       "children" : [
         {
           "artifactType" : "asset",
-          "path" : "Tuist-Filled.png\/Assets.car",
+          "path" : "App.app\/Assets.car\/Tuist-Filled.png",
           "shasum" : "880c0fec121c36e2fe248e730234ccd6cdea5bbe46dea6c132d7c9bfb6a4e32b",
           "size" : 699
         },
         {
           "artifactType" : "asset",
-          "path" : "Tuist-Filled@2x.png\/Assets.car",
+          "path" : "App.app\/Assets.car\/Tuist-Filled@2x.png",
           "shasum" : "62618f6f558cd57f6ecd5a3171324b2328ba44df7f13fda31cee214bc9ba2b10",
           "size" : 1370
         },
         {
           "artifactType" : "asset",
-          "path" : "Tuist-Filled@3x.png\/Assets.car",
+          "path" : "App.app\/Assets.car\/Tuist-Filled@3x.png",
           "shasum" : "3171a380ea518c7de3fd35a0cb5a5dcb47d9df2bb72a2c7d75f48762dbda6463",
           "size" : 2033
         }

--- a/Tests/RosalindTests/__Snapshots__/RosalindAcceptanceTests/ios_app_ipa.1
+++ b/Tests/RosalindTests/__Snapshots__/RosalindAcceptanceTests/ios_app_ipa.1
@@ -11,19 +11,19 @@
       "children" : [
         {
           "artifactType" : "asset",
-          "path" : "Tuist-Filled.png\/Assets.car",
+          "path" : "App.app\/Assets.car\/Tuist-Filled.png",
           "shasum" : "880c0fec121c36e2fe248e730234ccd6cdea5bbe46dea6c132d7c9bfb6a4e32b",
           "size" : 699
         },
         {
           "artifactType" : "asset",
-          "path" : "Tuist-Filled@2x.png\/Assets.car",
+          "path" : "App.app\/Assets.car\/Tuist-Filled@2x.png",
           "shasum" : "62618f6f558cd57f6ecd5a3171324b2328ba44df7f13fda31cee214bc9ba2b10",
           "size" : 1370
         },
         {
           "artifactType" : "asset",
-          "path" : "Tuist-Filled@3x.png\/Assets.car",
+          "path" : "App.app\/Assets.car\/Tuist-Filled@3x.png",
           "shasum" : "3171a380ea518c7de3fd35a0cb5a5dcb47d9df2bb72a2c7d75f48762dbda6463",
           "size" : 2033
         }

--- a/Tests/RosalindTests/__Snapshots__/RosalindAcceptanceTests/ios_app_xcarchive.1
+++ b/Tests/RosalindTests/__Snapshots__/RosalindAcceptanceTests/ios_app_xcarchive.1
@@ -11,19 +11,19 @@
       "children" : [
         {
           "artifactType" : "asset",
-          "path" : "Tuist-Filled.png\/Assets.car",
+          "path" : "App.app\/Assets.car\/Tuist-Filled.png",
           "shasum" : "880c0fec121c36e2fe248e730234ccd6cdea5bbe46dea6c132d7c9bfb6a4e32b",
           "size" : 699
         },
         {
           "artifactType" : "asset",
-          "path" : "Tuist-Filled@2x.png\/Assets.car",
+          "path" : "App.app\/Assets.car\/Tuist-Filled@2x.png",
           "shasum" : "62618f6f558cd57f6ecd5a3171324b2328ba44df7f13fda31cee214bc9ba2b10",
           "size" : 1370
         },
         {
           "artifactType" : "asset",
-          "path" : "Tuist-Filled@3x.png\/Assets.car",
+          "path" : "App.app\/Assets.car\/Tuist-Filled@3x.png",
           "shasum" : "3171a380ea518c7de3fd35a0cb5a5dcb47d9df2bb72a2c7d75f48762dbda6463",
           "size" : 2033
         }


### PR DESCRIPTION
The path for the assets in `Asset.car` was not correct (see change in the acceptance tests)