### PR TITLE
ci: build the macOS jobs with the toolchain of the selected Xcode

### DIFF
--- a/.github/workflows/rosalind.yml
+++ b/.github/workflows/rosalind.yml
@@ -21,11 +21,15 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        swift: ["6.0"]
+        swift: ["6.2"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+      - name: Select Xcode
+        if: runner.os == 'macOS'
+        run: sudo xcode-select -switch /Applications/Xcode_$(cat .xcode-version).app
       - uses: SwiftyLab/setup-swift@latest
+        if: runner.os == 'Linux'
         with:
           swift-version: ${{ matrix.swift }}
       - uses: jdx/mise-action@v2
@@ -45,15 +49,11 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest]
-        swift: ["6.0"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - name: Select Xcode
         run: sudo xcode-select -switch /Applications/Xcode_$(cat .xcode-version).app
-      - uses: SwiftyLab/setup-swift@latest
-        with:
-          swift-version: ${{ matrix.swift }}
       - uses: jdx/mise-action@v2
         if: runner.os == 'Linux' || runner.os == 'macOS'
         with:


### PR DESCRIPTION
## What changed

The macOS jobs no longer install a standalone Swift toolchain. They use the toolchain of the Xcode selected from `.xcode-version`. Linux, which has no Xcode to take one from, keeps `SwiftyLab/setup-swift`, and that pin moves from 6.0 to 6.2.

## Why

Every macOS job on the repository currently fails, including on unmodified `main`. The workflow pinned Swift 6.0.3 while the runner image moved to an SDK built with Swift 6.2, and the two cannot be mixed:

```
failed to build module 'Darwin'; this SDK is not supported by the compiler (the SDK is built with 'Apple Swift version 6.2 (swiftlang-6.2.0.17.14 clang-1700.3.17.1)', while this compiler is 'Apple Swift version 6.0.3')
```

The failure happens while compiling `Package.swift`, before any source in this repository is touched, so it takes out the build and test jobs on macOS and fail-fast then cancels the Linux build. The last green run on `main` is from 2026-06-19, on an older image.

Bumping the pinned version to match the image would work until the image moves again. Pinning a standalone toolchain *and* an Xcode means both have to stay compatible with each other and with whatever the runner ships, which is what broke here. Taking the toolchain from the selected Xcode removes that pairing on macOS and leaves `.xcode-version` as the single thing to bump.

The macOS build job also gained the `Select Xcode` step the test job already had, so both macOS jobs pin the same Xcode instead of one of them taking the image default.

## Validation

The jobs on this pull request. The suite passes locally against Xcode 26's Swift 6.3.2 (32 tests, 5 suites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
