### PR TITLE
fix: bump ZIPFoundation to 0.9.22 to pick up Linux inflate loop fix

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -195,8 +195,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/ZIPFoundation",
       "state" : {
-        "revision" : "a0e902e08e7a9ff3f0c1d109dc331b20cd498bb5",
-        "version" : "0.9.21"
+        "revision" : "dfdbf2b3c96f220d4af7bbabc2cd38671f0bd06d",
+        "version" : "0.9.22"
       }
     }
   ],


### PR DESCRIPTION
## What

Bumps `Package.resolved` to pin `tuist/ZIPFoundation` at `0.9.22`, the tag that carries the fix for an infinite loop in the Linux inflate path.

## Why

`Data.decode` in ZIPFoundation drives its outer decompression loop with `while result != Z_STREAM_END`, and `result` is only updated inside a `withUnsafeMutableBytes { rawBufferPointer.count > 0 }` block. When the provider returns an empty `Data` (source EOF) before the deflate stream has signalled `Z_STREAM_END`, the inner block is skipped, `result` is never updated, and the loop keeps calling the provider with the same value forever. On Linux this manifests as a silent 100% CPU spin with no output. Apple platforms take a different code path (`compression_stream_process`) and are not affected.

Ran into this in production while running `tuist inspect bundle` on GitHub Actions Ubuntu runners. Any archive whose deflate stream ends without a proper final-block marker, or whose central-directory `compressed_size` is even slightly inaccurate, hung the CLI until the workflow timeout fired (multi-hour cancellations). The bug is invisible because the loop is pure CPU work, no logging, no yield points, and no way for Swift Concurrency to cancel it.

`tuist/ZIPFoundation:0.9.22` carries the fix. The upstream PR is [weichsel/ZIPFoundation#389](https://github.com/weichsel/ZIPFoundation/pull/389); once that merges and gets tagged, we'll resync the `tuist` fork on top of upstream and drop our patch commit.

## How this was verified

Wrote a direct regression test in ZIPFoundation itself that hangs indefinitely before the fix and passes in ~1 ms after. Also reproduced the end-to-end Rosalind hang on a synthetic truncated-entry AAB and verified this bump makes it throw `CompressionError.corruptedData` cleanly instead of spinning.

## Follow-ups

- After merge, cut a Rosalind release so `tuist/tuist` can bump.
- The traits-related `swift package update` error on this repo (`swift-snapshot-testing` / `swift-custom-dump`) is unrelated and out of scope for this PR. Package.resolved was updated with a targeted edit to avoid noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)