### PR TITLE
fix: unzip an .aab exactly once during analysis

### DIFF
--- a/Sources/Rosalind/AndroidBundleMetadataService.swift
+++ b/Sources/Rosalind/AndroidBundleMetadataService.swift
@@ -32,6 +32,7 @@ struct AndroidBundleMetadata: Equatable {
 protocol AndroidBundleMetadataServicing: Sendable {
     func apkMetadata(at path: AbsolutePath) async throws -> AndroidBundleMetadata
     func aabMetadata(at path: AbsolutePath) async throws -> AndroidBundleMetadata
+    func aabMetadata(fromExtractedContentsAt extractedPath: AbsolutePath) async throws -> AndroidBundleMetadata
 }
 
 struct AndroidBundleMetadataService: AndroidBundleMetadataServicing {
@@ -85,37 +86,40 @@ struct AndroidBundleMetadataService: AndroidBundleMetadataServicing {
         try await fileSystem.runInTemporaryDirectory(prefix: "aab-metadata") { temporaryDirectory in
             let unzippedPath = temporaryDirectory.appending(component: path.basename)
             try await fileSystem.unzip(path, to: unzippedPath)
-
-            let manifestPath = unzippedPath.appending(components: "base", "manifest", "AndroidManifest.xml")
-            guard try await fileSystem.exists(manifestPath) else {
-                throw AndroidBundleMetadataServiceError.manifestNotFound(path)
-            }
-
-            let data = try await fileSystem.readFile(at: manifestPath)
-            let xmlNode = try Aapt_Pb_XmlNode(serializedBytes: data)
-            let attributes = xmlNode.element.attribute
-            let packageName = attributes.first(where: { $0.name == "package" })?.value
-            let versionName = attributes.first(where: { $0.name == "versionName" })?.value
-
-            guard let packageName, !packageName.isEmpty else {
-                throw AndroidBundleMetadataServiceError.parsingFailed(manifestPath)
-            }
-
-            var resourceTable: Aapt_Pb_ResourceTable?
-            let resourcesPath = unzippedPath.appending(components: "base", "resources.pb")
-            if try await fileSystem.exists(resourcesPath) {
-                let resourcesData = try await fileSystem.readFile(at: resourcesPath)
-                resourceTable = try Aapt_Pb_ResourceTable(serializedBytes: resourcesData)
-            }
-
-            let appName = applicationLabel(in: xmlNode, resourceTable: resourceTable)
-
-            return AndroidBundleMetadata(
-                packageName: packageName,
-                versionName: versionName ?? "1.0",
-                appName: appName ?? packageName
-            )
+            return try await aabMetadata(fromExtractedContentsAt: unzippedPath)
         }
+    }
+
+    func aabMetadata(fromExtractedContentsAt extractedPath: AbsolutePath) async throws -> AndroidBundleMetadata {
+        let manifestPath = extractedPath.appending(components: "base", "manifest", "AndroidManifest.xml")
+        guard try await fileSystem.exists(manifestPath) else {
+            throw AndroidBundleMetadataServiceError.manifestNotFound(extractedPath)
+        }
+
+        let data = try await fileSystem.readFile(at: manifestPath)
+        let xmlNode = try Aapt_Pb_XmlNode(serializedBytes: data)
+        let attributes = xmlNode.element.attribute
+        let packageName = attributes.first(where: { $0.name == "package" })?.value
+        let versionName = attributes.first(where: { $0.name == "versionName" })?.value
+
+        guard let packageName, !packageName.isEmpty else {
+            throw AndroidBundleMetadataServiceError.parsingFailed(manifestPath)
+        }
+
+        var resourceTable: Aapt_Pb_ResourceTable?
+        let resourcesPath = extractedPath.appending(components: "base", "resources.pb")
+        if try await fileSystem.exists(resourcesPath) {
+            let resourcesData = try await fileSystem.readFile(at: resourcesPath)
+            resourceTable = try Aapt_Pb_ResourceTable(serializedBytes: resourcesData)
+        }
+
+        let appName = applicationLabel(in: xmlNode, resourceTable: resourceTable)
+
+        return AndroidBundleMetadata(
+            packageName: packageName,
+            versionName: versionName ?? "1.0",
+            appName: appName ?? packageName
+        )
     }
 
     private func applicationLabel(

--- a/Sources/Rosalind/Rosalind.swift
+++ b/Sources/Rosalind/Rosalind.swift
@@ -141,7 +141,7 @@ public struct Rosalind: Rosalindable {
 
             let metadata: AndroidBundleMetadata
             if path.extension == "aab" {
-                metadata = try await androidBundleMetadataService.aabMetadata(at: path)
+                metadata = try await androidBundleMetadataService.aabMetadata(fromExtractedContentsAt: unzippedPath)
             } else {
                 metadata = try await androidBundleMetadataService.apkMetadata(at: path)
             }

--- a/Tests/RosalindTests/AndroidBundleMetadataServiceTests.swift
+++ b/Tests/RosalindTests/AndroidBundleMetadataServiceTests.swift
@@ -216,6 +216,42 @@ struct AndroidBundleMetadataServiceTests {
         }
     }
 
+    // MARK: - AAB Metadata from already-extracted contents
+
+    @Test func aabMetadata_fromExtractedContents_readsMetadataWithoutUnzipping() async throws {
+        let fileSystem = FileSystem()
+        let subject = AndroidBundleMetadataService(fileSystem: fileSystem)
+        let aabPath = try fixturePath("android_app/app.aab")
+
+        try await fileSystem.runInTemporaryDirectory(prefix: "extracted") { temporaryDirectory in
+            let extractedPath = temporaryDirectory.appending(component: "extracted")
+            try await fileSystem.unzip(aabPath, to: extractedPath)
+
+            let metadata = try await subject.aabMetadata(fromExtractedContentsAt: extractedPath)
+
+            #expect(metadata.packageName == "dev.tuist.example")
+            #expect(metadata.versionName == "1.0")
+            #expect(metadata.appName == "Simple Android App")
+        }
+    }
+
+    @Test func aabMetadata_fromExtractedContents_throws_whenManifestNotFound() async throws {
+        let fileSystem = FileSystem()
+        let subject = AndroidBundleMetadataService(fileSystem: fileSystem)
+
+        try await fileSystem.runInTemporaryDirectory(prefix: "extracted") { temporaryDirectory in
+            let extractedPath = temporaryDirectory.appending(component: "extracted")
+            try await fileSystem.makeDirectory(at: extractedPath.appending(component: "base"))
+
+            await #expect {
+                try await subject.aabMetadata(fromExtractedContentsAt: extractedPath)
+            } throws: { error in
+                if let e = error as? AndroidBundleMetadataServiceError, case .manifestNotFound = e { return true }
+                return false
+            }
+        }
+    }
+
     // MARK: - Helpers
 
     private func fixturePath(_ relativePath: String) throws -> AbsolutePath {

--- a/Tests/RosalindTests/RosalindTests.swift
+++ b/Tests/RosalindTests/RosalindTests.swift
@@ -298,7 +298,7 @@ struct RosalindTests {
             try await fileSystem.zipFileOrDirectoryContent(at: aabContentsPath, to: aabPath)
 
             given(androidBundleMetadataService)
-                .aabMetadata(at: .any)
+                .aabMetadata(fromExtractedContentsAt: .any)
                 .willReturn(AndroidBundleMetadata(
                     packageName: "com.test.app",
                     versionName: "2.0",
@@ -329,6 +329,13 @@ struct RosalindTests {
             let soArtifact = got.artifacts
                 .first(where: { $0.path == "com.test.app/libapp.so" })
             #expect(soArtifact?.artifactType == .binary)
+
+            verify(androidBundleMetadataService)
+                .aabMetadata(fromExtractedContentsAt: .any)
+                .called(1)
+            verify(androidBundleMetadataService)
+                .aabMetadata(at: .any)
+                .called(0)
         }
     }
 


### PR DESCRIPTION
## What

`Rosalind.analyzeAndroidBundle` currently extracts the `.aab` twice:

1. Once in `Rosalind.analyzeAndroidBundle` into the outer temporary directory to walk the artifact tree.
2. Again inside `AndroidBundleMetadataService.aabMetadata(at:)` into a separate temporary directory just to read `base/manifest/AndroidManifest.xml` and `base/resources.pb`.

For a real-world bundle (~185 MB compressed, ~266 MB extracted) that is roughly half a gigabyte of duplicated decompression work on the runner's disk before we've hashed a single file, plus a doubled peak footprint that bites on memory- or disk-tight CI runners.

`AndroidBundleMetadataService.aabMetadata(at:)` keeps its existing signature so external callers with only the raw `.aab` keep working. It now extracts into a temporary directory once and delegates to a new `aabMetadata(fromExtractedContentsAt:)`, which reads the manifest and (optionally) the resource table directly from an already-extracted directory. `Rosalind.analyzeAndroidBundle` calls this new entry point with the directory it already extracted, so a single unzip pass covers both the metadata read and the artifact walk.

## Impact

Local Docker benchmarks on `linux/arm64` with a 268 MB, 4,826-entry synthetic AAB shaped like a real Android production build:

| | Before | After |
|---|---|---|
| Linux arm64 (Docker) | ~36s | ~18s |
| macOS arm64 | ~12s | ~4.4s |

Roughly 2-3x wall-clock reduction on real Android bundles, plus a lower peak disk footprint during analysis.

## Tests

- `AndroidBundleMetadataServiceTests`:
  - `aabMetadata_fromExtractedContents_readsMetadataWithoutUnzipping` exercises the new API against the existing `android_app/app.aab` fixture and asserts the returned metadata.
  - `aabMetadata_fromExtractedContents_throws_whenManifestNotFound` locks in the missing-manifest error path.
- `RosalindTests.aabBundle` now asserts `verify(...).aabMetadata(fromExtractedContentsAt: .any).called(1)` **and** `verify(...).aabMetadata(at: .any).called(0)`. That locks the single-unzip invariant in place: a future regression that walks back to the raw `.aab` API from `analyzeAndroidBundle` fails the assertion instead of silently doubling the work again.

## Context

Surfaced during the investigation of the Linux `tuist inspect bundle` hang. The underlying culprit turned out to be a separate infinite loop in ZIPFoundation's inflate path on Linux, but along the way this double-extraction was verified with a reproducible benchmark and turns out to be a genuine 2-3x wall-clock win on its own. Ships independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)